### PR TITLE
Fix [switch] parameters in PowerShell scripts being passed as strings.

### DIFF
--- a/Windows/Inedo.Windows.Common/PowerShell/PSUtil.cs
+++ b/Windows/Inedo.Windows.Common/PowerShell/PSUtil.cs
@@ -35,6 +35,8 @@ namespace Inedo.Extensions.Windows.PowerShell
                 {
                     var value = PowerShellScriptRunner.ConvertToPSValue(var.Value);
                     var param = scriptInfo.Parameters.FirstOrDefault(p => string.Equals(p.Name, var.Key, StringComparison.OrdinalIgnoreCase));
+                    if (param != null && param.IsBooleanOrSwitch)
+                        value = Convert.ToBoolean(value);
                     if (param != null)
                         parameters[param.Name] = value;
                     else


### PR DESCRIPTION
Fixes #29.